### PR TITLE
fix: go linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Lint go code (golangci-lint)
         uses: golangci/golangci-lint-action@v3
-        if: steps.changed-go-files.outputs.any-changed == 'true'
+        if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
           version: v1.45
 


### PR DESCRIPTION
According to the documentation of [changed-files](https://github.com/tj-actions/changed-files) action, variable used to detect if files has been changed is not `any-changed` but `any_changed` 

See : https://github.com/tj-actions/changed-files#outputs

Fixe has been done on https://github.com/okp4/cosmos-faucet/pull/4 project and successfully tested. 