### PR TITLE
Ci/update go & co versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.3.0
         with:
-          go-version: "1.18.1"
+          go-version: "1.19"
 
       - name: Build go project
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,7 +73,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
-          version: v1.45
+          version: v1.49
 
   lint-dockerfile:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/setup-go@v3.3.0
         if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
-          go-version: "1.18.2"
+          go-version: "1.19"
 
       - name: Lint go code (golangci-lint)
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,6 +63,12 @@ jobs:
             go.mod
             go.sum
 
+      - name: Setup Go environment
+        uses: actions/setup-go@v3.3.0
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        with:
+          go-version: "1.18.2"
+
       - name: Lint go code (golangci-lint)
         uses: golangci/golangci-lint-action@v3
         if: steps.changed-go-files.outputs.any_changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.3.0
         with:
-          go-version: "1.18.1"
+          go-version: "1.19"
 
       - name: Release project
         uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.3.0
         with:
-          go-version: "1.18.1"
+          go-version: "1.19"
 
       - name: Test go project
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #--- Build stage
-FROM golang:1.18.3-stretch AS go-builder
+FROM golang:1.19-bullseye AS go-builder
 
 WORKDIR /src
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BINARY_NAME             = template-go
 TARGET_FOLDER           = target
 DIST_FOLDER             = $(TARGET_FOLDER)/dist
-DOCKER_IMAGE_GOLANG_CI  = golangci/golangci-lint:v1.45.2
+DOCKER_IMAGE_GOLANG_CI  = golangci/golangci-lint:v1.49
 
 # Some colors
 COLOR_GREEN  = $(shell tput -Txterm setaf 2)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module okp4/template-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/spf13/cobra v1.5.0


### PR DESCRIPTION
This PR simply updates the following targets:
- [golang](https://tip.golang.org/doc/go1.19) to v1.19 (as well as the docker image to golang:1.19-bullseye)
- [golangci/golangci-lint](https://github.com/golangci/golangci-lint/releases/tag/v1.49.0) to v1.49