### PR TITLE
🐛 Fix: changed-files breaking changes on 31.0.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,10 +53,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Find changed go files
         id: changed-go-files
-        uses: tj-actions/changed-files@v29.0.9
+        uses: tj-actions/changed-files@v31.0.1
         with:
           files: |
             **/*.go

--- a/.github/workflows/thank.yml
+++ b/.github/workflows/thank.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Find changed dependencies
         id: changed-dependencies
-        uses: tj-actions/changed-files@v29.0.9
+        uses: tj-actions/changed-files@v31.0.1
         with:
           files: |
             go.mod


### PR DESCRIPTION
Fix changed-files action after update to 31.0.1. A breaking change has been introduce, now the comparaison is done with commit SHA and to do that we need to add fetch-depth parameter to actions/checkout. 

Fix @dependabot update #56.